### PR TITLE
fix for PR #6

### DIFF
--- a/skirmish-report.xsl
+++ b/skirmish-report.xsl
@@ -1301,22 +1301,16 @@
     </xsl:template>
     <xsl:template name="timestamp-from-seconds">
         <xsl:param name="seconds" />
-        <xsl:variable name="abs-seconds" select="number(concat(substring(string($seconds), 1, number($seconds >= 0) * string-length(string($seconds))), substring(string($seconds * -1), 1, number(not($seconds >= 0)) * string-length(string($seconds * -1)))))" />
+        <xsl:if test="$seconds &lt; 0">-</xsl:if>
+        <xsl:variable name="abs-seconds" select="$seconds * (1 - 2*($seconds &lt; 0))" />
         <xsl:variable name="hours" select="floor($abs-seconds div 3600)" />
-        <xsl:variable name="minutes" select="floor($abs-seconds div 60)" />
-        <xsl:variable name="seconds-parsed" select="floor($abs-seconds mod 60)" />
-        <xsl:if test="$hours != 0">
-            <xsl:value-of select="$hours" />
-        </xsl:if>
+        <xsl:variable name="seconds-for-minutes" select="$abs-seconds - ($hours * 3600)" />
+        <xsl:variable name="minutes" select="floor($seconds-for-minutes div 60)" />
+        <xsl:variable name="seconds-left" select="$seconds-for-minutes - ($minutes * 60)" />
         <xsl:choose>
-            <xsl:when test="$hours != 0">:<xsl:value-of select="format-number($minutes, '00')" /></xsl:when>
-            <xsl:when test="$minutes = 0">0:</xsl:when>
+            <xsl:when test="$hours != 0"><xsl:value-of select="$hours" />:<xsl:value-of select="format-number($minutes, '00')" /></xsl:when>
             <xsl:otherwise><xsl:value-of select="$minutes" /></xsl:otherwise>
-        </xsl:choose>
-        <xsl:choose>
-            <xsl:when test="$minutes != 0">:<xsl:value-of select="format-number($seconds-parsed, '00')" /></xsl:when>
-            <xsl:otherwise><xsl:value-of select="format-number($seconds-parsed, '00')" /></xsl:otherwise>
-        </xsl:choose>
+        </xsl:choose>:<xsl:value-of select="format-number($seconds-left, '00')" />
     </xsl:template>
     <xsl:template name="missile-desc">
         <xsl:param name="desc" />


### PR DESCRIPTION
corrects the issues in PR #6:

- duplicate variables renamed 

- seems like site is not a xslt 2.0 processor, changed abs-seconds to use an expression compatible with xslt 1.0